### PR TITLE
If jsonschema contains format, inline it along with type information

### DIFF
--- a/jsonschema2md/__init__.py
+++ b/jsonschema2md/__init__.py
@@ -182,12 +182,17 @@ class Parser:
 
         # Add full line to output
         description_line = " ".join(description_line)
+        optional_format = ""
         if name is None:
-            obj_type = f"*{obj['type']}*" if "type" in obj else ""
+            if "format" in obj:
+                optional_format = f", format: {obj['format']}"
+            obj_type = f"*{obj['type']}{optional_format}*" if "type" in obj else ""
             name_formatted = ""
         else:
+            if "format" in obj:
+                optional_format = f", format: {obj['format']}"
             required_str = ", required" if required else ""
-            obj_type = f" *({obj['type']}{required_str})*" if "type" in obj else ""
+            obj_type = f" *({obj['type']}{optional_format}{required_str})*" if "type" in obj else ""
             name_formatted = f"**`{name}`**" if name_monospace else f"**{name}**"
         anchor = f"<a id=\"{'/'.join(path)}\"></a>" if path else ""
         output_lines.append(f"{indentation}- {anchor}{name_formatted}{obj_type}{description_line}\n")

--- a/tests/test_jsonschema2md.py
+++ b/tests/test_jsonschema2md.py
@@ -37,6 +37,11 @@ class TestParser:
                         "type": "boolean",
                         "description": "Do I like this vegetable?",
                     },
+                    "expiresAt": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "When does the veggie expires",
+                    },
                 },
             }
         },
@@ -201,6 +206,7 @@ class TestParser:
             '- <a id="definitions/veggie"></a>**`veggie`** *(object)*\n',
             "  - **`veggieName`** *(string, required)*: The name of the vegetable.\n",
             "  - **`veggieLike`** *(boolean, required)*: Do I like this vegetable?\n",
+            "  - **`expiresAt`** *(string, format: date)*: When does the veggie expires.\n",
             "## Examples\n\n",
             "  ```json\n"
             "  {\n"
@@ -236,6 +242,7 @@ class TestParser:
             '- <a id="definitions/veggie"></a>**`veggie`** *(object)*\n',
             "  - **`veggieName`** *(string, required)*: The name of the vegetable.\n",
             "  - **`veggieLike`** *(boolean, required)*: Do I like this vegetable?\n",
+            "  - **`expiresAt`** *(string, format: date)*: When does the veggie expires.\n",
             "## Examples\n\n",
             "  ```yaml\n  fruits:\n  - apple\n  - orange\n  vegetables:\n  -   veggieLike: true\n      veggieName: cabbage\n  ```\n\n",
         ]


### PR DESCRIPTION
Json schema can contain format information. 

For example: string can have builtin format like date. https://json-schema.org/understanding-json-schema/reference/string.html

I added test to reflect the format information. 