### PR TITLE
Support `$def` keyword

### DIFF
--- a/jsonschema2md/__init__.py
+++ b/jsonschema2md/__init__.py
@@ -19,6 +19,7 @@ import subprocess  # nosec
 import sys
 from collections.abc import Sequence
 from typing import Optional, Union
+from urllib.parse import quote
 
 import yaml
 
@@ -100,7 +101,7 @@ class Parser:
             else:
                 description_line.append("Cannot contain additional properties.")
         if "$ref" in obj:
-            description_line.append(f"Refer to *[{obj['$ref']}](#{obj['$ref'][2:]})*.")
+            description_line.append(f"Refer to *[{obj['$ref']}](#{quote(obj['$ref'][2:])})*.")
         if "default" in obj:
             description_line.append(f"Default: `{json.dumps(obj['default'])}`.")
 
@@ -190,7 +191,7 @@ class Parser:
             required_str = ", required" if required else ""
             obj_type = f" *({obj['type']}{optional_format}{required_str})*" if "type" in obj else ""
             name_formatted = f"**`{name}`**" if name_monospace else f"**{name}**"
-        anchor = f"<a id=\"{'/'.join(path)}\"></a>" if path else ""
+        anchor = f"<a id=\"{quote('/'.join(path))}\"></a>" if path else ""
         output_lines.append(f"{indentation}- {anchor}{name_formatted}{obj_type}{description_line}\n")
 
         # Recursively parse subschemas following schema composition keywords
@@ -212,7 +213,7 @@ class Parser:
                     )
 
         # Recursively add items and definitions
-        for property_name in ["items", "definitions"]:
+        for property_name in ["items", "definitions", "$defs"]:
             if property_name in obj:
                 output_lines = self._parse_object(
                     obj[property_name],
@@ -286,13 +287,18 @@ class Parser:
             for obj_name, obj in schema_object["patternProperties"].items():
                 output_lines.extend(self._parse_object(obj, obj_name))
 
-        # Add properties and definitions
-        for name in ["properties", "definitions"]:
+        # Add properties
+        if "properties" in schema_object:
+            output_lines.append("## Properties\n\n")
+            for obj_name, obj in schema_object["properties"].items():
+                output_lines.extend(self._parse_object(obj, obj_name))
+
+        # Add definitions
+        for name in ["definitions", "$defs"]:
             if name in schema_object:
-                output_lines.append(f"## {name.capitalize()}\n\n")
+                output_lines.append("## Definitions\n\n")
                 for obj_name, obj in schema_object[name].items():
-                    path = [name, obj_name] if name == "definitions" else []
-                    output_lines.extend(self._parse_object(obj, obj_name, path=path))
+                    output_lines.extend(self._parse_object(obj, obj_name, path=[name, obj_name]))
 
         # Add examples
         if "examples" in schema_object and self.show_examples in ["all", "object"]:

--- a/jsonschema2md/__init__.py
+++ b/jsonschema2md/__init__.py
@@ -293,7 +293,7 @@ class Parser:
             for obj_name, obj in schema_object["properties"].items():
                 output_lines.extend(self._parse_object(obj, obj_name))
 
-        # Add definitions
+        # Add definitions / $defs
         for name in ["definitions", "$defs"]:
             if name in schema_object:
                 output_lines.append("## Definitions\n\n")

--- a/tests/test_jsonschema2md.py
+++ b/tests/test_jsonschema2md.py
@@ -4,6 +4,92 @@
 import jsonschema2md
 
 
+class TestDraft201909defs:
+    test_schema = {
+        "$id": "https://example.com/arrays.schema.json",
+        "$schema": "http://json-schema.org/draft/2019-09/schema",
+        "description": "Vegetable preferences",
+        "type": "object",
+        "additionalProperties": {
+            "description": "Additional info about foods you may like",
+            "type": "object",
+            "patternProperties": {
+                "^iLike(Meat|Drinks)$": {
+                    "type": "boolean",
+                    "description": "Do I like it?",
+                }
+            },
+        },
+        "properties": {
+            "fruits": {"type": "array", "items": {"type": "string"}},
+            "vegetables": {"type": "array", "items": {"$ref": "#/$defs/veggie"}},
+        },
+        "$defs": {
+            "veggie": {
+                "type": "object",
+                "required": ["veggieName", "veggieLike"],
+                "properties": {
+                    "veggieName": {
+                        "type": "string",
+                        "description": "The name of the vegetable.",
+                    },
+                    "veggieLike": {
+                        "type": "boolean",
+                        "description": "Do I like this vegetable?",
+                    },
+                    "expiresAt": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "When does the veggie expires",
+                    },
+                },
+            }
+        },
+        "examples": [
+            {
+                "fruits": ["apple", "orange"],
+                "vegetables": [{"veggieName": "cabbage", "veggieLike": True}],
+            }
+        ],
+    }
+
+    def test_parse_schema(self):
+        parser = jsonschema2md.Parser()
+        expected_output = [
+            "# JSON Schema\n\n",
+            "*Vegetable preferences*\n\n",
+            "## Additional Properties\n" "\n",
+            "- **Additional Properties** *(object)*: Additional info about foods you may " "like.\n",
+            "  - **`^iLike(Meat|Drinks)$`** *(boolean)*: Do I like it?\n",
+            "## Properties\n\n",
+            "- **`fruits`** *(array)*\n",
+            "  - **Items** *(string)*\n",
+            "- **`vegetables`** *(array)*\n",
+            "  - **Items**: Refer to *[#/$defs/veggie](#%24defs/veggie)*.\n",
+            "## Definitions\n\n",
+            '- <a id="%24defs/veggie"></a>**`veggie`** *(object)*\n',
+            "  - **`veggieName`** *(string, required)*: The name of the vegetable.\n",
+            "  - **`veggieLike`** *(boolean, required)*: Do I like this vegetable?\n",
+            "  - **`expiresAt`** *(string, format: date)*: When does the veggie expires.\n",
+            "## Examples\n\n",
+            "  ```json\n"
+            "  {\n"
+            '      "fruits": [\n'
+            '          "apple",\n'
+            '          "orange"\n'
+            "      ],\n"
+            '      "vegetables": [\n'
+            "          {\n"
+            '              "veggieName": "cabbage",\n'
+            '              "veggieLike": true\n'
+            "          }\n"
+            "      ]\n"
+            "  }\n"
+            "  ```\n\n",
+        ]
+        assert expected_output == parser.parse_schema(self.test_schema)
+
+
 class TestParser:
     test_schema = {
         "$id": "https://example.com/arrays.schema.json",


### PR DESCRIPTION
The 2019 draft of json schema renamed the `definitions` keyword to `$defs`.  
> https://json-schema.org/draft/2019-09/release-notes#keyword-changes

The pull request supports the presence of either keyword in the schema, but for cosmetic purposes outputs the section as `## Definitions`.  Additionally, the link strings are passed through `urllib.parse.quote()`.  Escaping the '$' avoids the somewhat edge case issue where certain Markdown viewers interpret the text between two '$' as a Latex/Katex expression.  The implementation separates handling 'properties' from 'definitions' to avoid complicating the logic. [`__init__.py:290-295`](https://github.com/sbrunner/jsonschema2md/blob/3010ccfe06e69833711b919e542d0daddbd3066c/jsonschema2md/__init__.py#L290-L295)

A passing test case was added, and the Github CI script completes successfully.

It's fully understandable if these changes are considered 'off mission' for the project, but I thought I'd offer them up.