### PR TITLE
Disable keys sorting for yaml example to allow for nicer output

### DIFF
--- a/jsonschema2md/__init__.py
+++ b/jsonschema2md/__init__.py
@@ -119,7 +119,7 @@ class Parser:
             return "".join(result)
 
         def dump_yaml_with_line_head(obj, line_head, **kwargs):
-            result = [line_head + line for line in io.StringIO(yaml.dump(obj, **kwargs)).readlines()]
+            result = [line_head + line for line in io.StringIO(yaml.dump(obj, sort_keys=False, **kwargs)).readlines()]
             return "".join(result).rstrip()
 
         example_lines = []

--- a/jsonschema2md/__init__.py
+++ b/jsonschema2md/__init__.py
@@ -119,7 +119,10 @@ class Parser:
             return "".join(result)
 
         def dump_yaml_with_line_head(obj, line_head, **kwargs):
-            result = [line_head + line for line in io.StringIO(yaml.dump(obj, sort_keys=False, **kwargs)).readlines()]
+            result = [
+                line_head + line
+                for line in io.StringIO(yaml.dump(obj, sort_keys=False, **kwargs)).readlines()
+            ]
             return "".join(result).rstrip()
 
         example_lines = []

--- a/tests/test_jsonschema2md.py
+++ b/tests/test_jsonschema2md.py
@@ -343,7 +343,7 @@ class TestParser:
             "  - **`veggieLike`** *(boolean, required)*: Do I like this vegetable?\n",
             "  - **`expiresAt`** *(string, format: date)*: When does the veggie expires.\n",
             "## Examples\n\n",
-            "  ```yaml\n  fruits:\n  - apple\n  - orange\n  vegetables:\n  -   veggieLike: true\n      veggieName: cabbage\n  ```\n\n",
+            "  ```yaml\n  fruits:\n  - apple\n  - orange\n  vegetables:\n  -   veggieName: cabbage\n      veggieLike: true\n  ```\n\n",
         ]
         assert expected_output == parser.parse_schema(self.test_schema)
 


### PR DESCRIPTION
Disable default sorting of yaml keys allows for nicer output as the developer of the json schema can preserve the order of the keys he defined in the resulting markdown output.

It also keeps consistency with the json example output as currently the key order is different for both formats.