### PR TITLE
Also document the required argument outside of definitions

### DIFF
--- a/examples/basic.json
+++ b/examples/basic.json
@@ -17,5 +17,6 @@
       "type": "integer",
       "minimum": 0
     }
-  }, "required": ["firstName"]
+  },
+  "required": ["firstName"]
 }

--- a/examples/basic.json
+++ b/examples/basic.json
@@ -17,5 +17,5 @@
       "type": "integer",
       "minimum": 0
     }
-  }
+  }, "required": ["firstName"]
 }

--- a/examples/basic.md
+++ b/examples/basic.md
@@ -2,6 +2,6 @@
 
 ## Properties
 
-- **`firstName`** _(string)_: The person's first name.
+- **`firstName`** _(string, required)_: The person's first name.
 - **`lastName`** _(string)_: The person's last name.
 - **`age`** _(integer)_: Age in years which must be equal to or greater than zero. Minimum: `0`.

--- a/examples/basic.md
+++ b/examples/basic.md
@@ -2,6 +2,6 @@
 
 ## Properties
 
-- **`firstName`** *(string, required)*: The person's first name.
-- **`lastName`** *(string)*: The person's last name.
-- **`age`** *(integer)*: Age in years which must be equal to or greater than zero. Minimum: `0`.
+- **`firstName`** _(string)_: The person's first name.
+- **`lastName`** _(string)_: The person's last name.
+- **`age`** _(integer)_: Age in years which must be equal to or greater than zero. Minimum: `0`.

--- a/examples/basic.md
+++ b/examples/basic.md
@@ -2,6 +2,6 @@
 
 ## Properties
 
-- **`firstName`** _(string)_: The person's first name.
-- **`lastName`** _(string)_: The person's last name.
-- **`age`** _(integer)_: Age in years which must be equal to or greater than zero. Minimum: `0`.
+- **`firstName`** *(string, required)*: The person's first name.
+- **`lastName`** *(string)*: The person's last name.
+- **`age`** *(integer)*: Age in years which must be equal to or greater than zero. Minimum: `0`.

--- a/examples/ms2rescore.md
+++ b/examples/ms2rescore.md
@@ -32,7 +32,7 @@ _MS²ReScore JSON configuration file._
       - _string_
       - _null_
   - **`log_level`** _(string)_: Logging level. Must be one of: `["debug", "info", "warning", "error", "critical"]`.
-  - **`const`** _(string)_: Const attribute.
+  - **`const`** _(string)_: Const attribute. Must be: `"value"`.
 - **`ms2pip`** _(object)_: MS²PIP settings. Cannot contain additional properties.
   - **`model`** _(string)_: MS²PIP model to use (see MS²PIP documentation). Default: `"HCD"`.
   - **`frag_error`** _(number)_: MS2 error tolerance in Da. Minimum: `0`. Default: `0.02`.

--- a/examples/ms2rescore.md
+++ b/examples/ms2rescore.md
@@ -32,7 +32,7 @@ _MS²ReScore JSON configuration file._
       - _string_
       - _null_
   - **`log_level`** _(string)_: Logging level. Must be one of: `["debug", "info", "warning", "error", "critical"]`.
-  - **`const`** _(string)_: Const attribute. Must be: `"value"`.
+  - **`const`** _(string)_: Const attribute.
 - **`ms2pip`** _(object)_: MS²PIP settings. Cannot contain additional properties.
   - **`model`** _(string)_: MS²PIP model to use (see MS²PIP documentation). Default: `"HCD"`.
   - **`frag_error`** _(number)_: MS2 error tolerance in Da. Minimum: `0`. Default: `0.02`.

--- a/jsonschema2md/__init__.py
+++ b/jsonschema2md/__init__.py
@@ -19,7 +19,6 @@ import sys
 from collections.abc import Sequence
 from typing import Optional, Union
 from urllib.parse import quote
-
 import yaml
 
 __version__ = version("jsonschema2md")
@@ -261,7 +260,6 @@ class Parser:
     def parse_schema(self, schema_object: dict) -> Sequence[str]:
         """Parse JSON Schema object to markdown text."""
         output_lines = []
-
         # Add title and description
         if "title" in schema_object:
             output_lines.append(f"# {schema_object['title']}\n\n")
@@ -288,7 +286,7 @@ class Parser:
                         name_monospace=False,
                     )
                 )
-
+        
         # Add pattern properties
         if "patternProperties" in schema_object:
             output_lines.append("## Pattern Properties\n\n")
@@ -299,7 +297,11 @@ class Parser:
         if "properties" in schema_object:
             output_lines.append("## Properties\n\n")
             for obj_name, obj in schema_object["properties"].items():
-                output_lines.extend(self._parse_object(obj, obj_name))
+                required = False
+                if "required" in schema_object:
+                    if obj_name in schema_object["required"]:
+                        required = True
+                output_lines.extend(self._parse_object(obj, obj_name, required=required))
 
         # Add definitions / $defs
         for name in ["definitions", "$defs"]:

--- a/jsonschema2md/__init__.py
+++ b/jsonschema2md/__init__.py
@@ -19,6 +19,7 @@ import sys
 from collections.abc import Sequence
 from typing import Optional, Union
 from urllib.parse import quote
+
 import yaml
 
 __version__ = version("jsonschema2md")
@@ -260,6 +261,7 @@ class Parser:
     def parse_schema(self, schema_object: dict) -> Sequence[str]:
         """Parse JSON Schema object to markdown text."""
         output_lines = []
+        
         # Add title and description
         if "title" in schema_object:
             output_lines.append(f"# {schema_object['title']}\n\n")

--- a/jsonschema2md/__init__.py
+++ b/jsonschema2md/__init__.py
@@ -261,7 +261,7 @@ class Parser:
     def parse_schema(self, schema_object: dict) -> Sequence[str]:
         """Parse JSON Schema object to markdown text."""
         output_lines = []
-        
+
         # Add title and description
         if "title" in schema_object:
             output_lines.append(f"# {schema_object['title']}\n\n")
@@ -288,7 +288,7 @@ class Parser:
                         name_monospace=False,
                     )
                 )
-        
+
         # Add pattern properties
         if "patternProperties" in schema_object:
             output_lines.append("## Pattern Properties\n\n")

--- a/tests/test_jsonschema2md.py
+++ b/tests/test_jsonschema2md.py
@@ -34,6 +34,7 @@ class TestDraft201909defs:
             "fruits": {"type": "array", "items": {"type": "string"}},
             "vegetables": {"type": "array", "items": {"$ref": "#/$defs/veggie"}},
         },
+        "required": ["fruits"], 
         "$defs": {
             "veggie": {
                 "type": "object",
@@ -75,7 +76,7 @@ class TestDraft201909defs:
             "- **Unevaluated Properties** *(object)*: Anything else you want to add. Cannot contain additional properties.\n",
             "  - **`^extraInfo[\\w]*$`** *(string)*: Anything else I might like to say.\n",
             "## Properties\n\n",
-            "- **`fruits`** *(array)*\n",
+            "- **`fruits`** *(array, required)*\n",
             "  - **Items** *(string)*\n",
             "- **`vegetables`** *(array)*\n",
             "  - **Items**: Refer to *[#/$defs/veggie](#%24defs/veggie)*.\n",

--- a/tests/test_jsonschema2md.py
+++ b/tests/test_jsonschema2md.py
@@ -34,7 +34,7 @@ class TestDraft201909defs:
             "fruits": {"type": "array", "items": {"type": "string"}},
             "vegetables": {"type": "array", "items": {"$ref": "#/$defs/veggie"}},
         },
-        "required": ["fruits"], 
+        "required": ["fruits"],
         "$defs": {
             "veggie": {
                 "type": "object",


### PR DESCRIPTION
In #18  you introduced the possibility to show `required` attributes. However, this only worked properly within the `definitions` keyword. This was reported in #330. 

This PR fixes the issue, tests the fix and added a simple documentation for the `basic.json` example.