### PR TITLE
Add support for `pattern` for regex constrained properties.

### DIFF
--- a/jsonschema2md/__init__.py
+++ b/jsonschema2md/__init__.py
@@ -73,6 +73,8 @@ class Parser:
         if add_type:
             if "type" in obj:
                 description_line.append(f"Must be of type *{obj['type']}*.")
+        if "pattern" in obj:
+            description_line.append(f"Must match pattern: `{obj['pattern']}`.")
         if "minimum" in obj:
             description_line.append(f"Minimum: `{obj['minimum']}`.")
         if "exclusiveMinimum" in obj:

--- a/tests/test_jsonschema2md.py
+++ b/tests/test_jsonschema2md.py
@@ -31,6 +31,8 @@ class TestDraft201909defs:
             },
         },
         "properties": {
+            "taste": {"type": "string", "description": "How does it taste?", "default": "good",
+                      "pattern": "^[a-z]*$"},
             "fruits": {"type": "array", "items": {"type": "string"}},
             "vegetables": {"type": "array", "items": {"$ref": "#/$defs/veggie"}},
         },
@@ -76,6 +78,7 @@ class TestDraft201909defs:
             "- **Unevaluated Properties** *(object)*: Anything else you want to add. Cannot contain additional properties.\n",
             "  - **`^extraInfo[\\w]*$`** *(string)*: Anything else I might like to say.\n",
             "## Properties\n\n",
+            "- **`taste`** *(string)*: How does it taste? Must match pattern: `^[a-z]*$`. Default: `\"good\"`.\n",
             "- **`fruits`** *(array, required)*\n",
             "  - **Items** *(string)*\n",
             "- **`vegetables`** *(array)*\n",


### PR DESCRIPTION
The [JSON Schema spec](https://json-schema.org/draft/2020-12/json-schema-validation#name-pattern) includes the `pattern` constraint for properties, but this gets ignored when generating the markdown. This PR fixes this.

The `_construct_description_line` function has been extended to also look for the `pattern` keyword and the markdown generation test has been updated to include a pattern constrained property.