### PR TITLE
Path ignore filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ print(''.join(md_lines))
   `False`)
 - `show-examples`: Parse examples for only the main object, only properties, or all.
   (`str`, default `all`, options: `object`, `properties`, `all`)
+- `header-level`: Base header level for the generated markdown. (`int`, default: `0`)
+- `ignore-patterns`: List of regex patterns to ignore when parsing the schema. (`list of
+str`, default: `None`)
 
 ## pre-commit hook
 

--- a/examples/basic.md
+++ b/examples/basic.md
@@ -2,6 +2,6 @@
 
 ## Properties
 
-- **`firstName`** _(string, required)_: The person's first name.
-- **`lastName`** _(string)_: The person's last name.
-- **`age`** _(integer)_: Age in years which must be equal to or greater than zero. Minimum: `0`.
+- <a id="properties/firstName"></a>**`firstName`** _(string, required)_: The person's first name.
+- <a id="properties/lastName"></a>**`lastName`** _(string)_: The person's last name.
+- <a id="properties/age"></a>**`age`** _(integer)_: Age in years which must be equal to or greater than zero. Minimum: `0`.

--- a/examples/food.md
+++ b/examples/food.md
@@ -4,17 +4,17 @@ _A representation of a person, company, organization, or place_
 
 ## Properties
 
-- **`fruits`** _(array)_
-  - **Items** _(string)_
-- **`vegetables`** _(array)_
-  - **Items**: Refer to _[#/definitions/veggie](#definitions/veggie)_.
+- <a id="properties/fruits"></a>**`fruits`** _(array)_
+  - <a id="properties/fruits/items"></a>**Items** _(string)_
+- <a id="properties/vegetables"></a>**`vegetables`** _(array)_
+  - <a id="properties/vegetables/items"></a>**Items**: Refer to _[#/definitions/veggie](#definitions/veggie)_.
 
 ## Definitions
 
 - <a id="definitions/veggie"></a>**`veggie`** _(object)_
 
-  - **`veggieName`** _(string, required)_: The name of the vegetable.
-  - **`veggieLike`** _(boolean, required)_: Do I like this vegetable?
+  - <a id="definitions/veggie/properties/veggieName"></a>**`veggieName`** _(string, required)_: The name of the vegetable.
+  - <a id="definitions/veggie/properties/veggieLike"></a>**`veggieLike`** _(boolean, required)_: Do I like this vegetable?
 
   Examples:
 

--- a/examples/ms2rescore.md
+++ b/examples/ms2rescore.md
@@ -4,54 +4,54 @@ _MS²ReScore JSON configuration file._
 
 ## Properties
 
-- **`general`** _(object)_: General MS²ReScore settings. Cannot contain additional properties.
-  - **`pipeline`** _(string)_: Pipeline to use, depending on input format. Must be one of: `["infer", "pin", "tandem", "maxquant", "msgfplus", "peptideshaker"]`. Default: `"infer"`.
-  - **`feature_sets`** _(array)_: Feature sets for which to generate PIN files and optionally run Percolator. Length must be at least 1. Items must be unique. Default: `["all"]`.
-    - **Items** _(string)_: Must be one of: `["all", "ms2pip_rt", "searchengine", "rt", "ms2pip"]`.
-  - **`id_decoy_pattern`**: Pattern used to identify the decoy PSMs in identification file. Passed to `--pattern` option of Percolator converters. Default: `null`.
+- <a id="properties/general"></a>**`general`** _(object)_: General MS²ReScore settings. Cannot contain additional properties.
+  - <a id="properties/general/properties/pipeline"></a>**`pipeline`** _(string)_: Pipeline to use, depending on input format. Must be one of: `["infer", "pin", "tandem", "maxquant", "msgfplus", "peptideshaker"]`. Default: `"infer"`.
+  - <a id="properties/general/properties/feature_sets"></a>**`feature_sets`** _(array)_: Feature sets for which to generate PIN files and optionally run Percolator. Length must be at least 1. Items must be unique. Default: `["all"]`.
+    - <a id="properties/general/properties/feature_sets/items"></a>**Items** _(string)_: Must be one of: `["all", "ms2pip_rt", "searchengine", "rt", "ms2pip"]`.
+  - <a id="properties/general/properties/id_decoy_pattern"></a>**`id_decoy_pattern`**: Pattern used to identify the decoy PSMs in identification file. Passed to `--pattern` option of Percolator converters. Default: `null`.
     - **One of**
-      - _string_
-      - _null_
-  - **`run_percolator`** _(boolean)_: Run Percolator within MS²ReScore. Default: `false`.
-  - **`num_cpu`** _(number)_: Number of parallel processes to use; -1 for all available. Minimum: `-1`. Must be an integer. Default: `-1`.
-  - **`config_file`**: Path to configuration file.
+      - <a id="properties/general/properties/id_decoy_pattern/oneOf/0"></a>_string_
+      - <a id="properties/general/properties/id_decoy_pattern/oneOf/1"></a>_null_
+  - <a id="properties/general/properties/run_percolator"></a>**`run_percolator`** _(boolean)_: Run Percolator within MS²ReScore. Default: `false`.
+  - <a id="properties/general/properties/num_cpu"></a>**`num_cpu`** _(number)_: Number of parallel processes to use; -1 for all available. Minimum: `-1`. Must be an integer. Default: `-1`.
+  - <a id="properties/general/properties/config_file"></a>**`config_file`**: Path to configuration file.
     - **One of**
-      - _string_
-      - _null_
-  - **`identification_file`** _(string)_: Path to identification file.
-  - **`mgf_path`**: Path to MGF file or directory with MGF files.
+      - <a id="properties/general/properties/config_file/oneOf/0"></a>_string_
+      - <a id="properties/general/properties/config_file/oneOf/1"></a>_null_
+  - <a id="properties/general/properties/identification_file"></a>**`identification_file`** _(string)_: Path to identification file.
+  - <a id="properties/general/properties/mgf_path"></a>**`mgf_path`**: Path to MGF file or directory with MGF files.
     - **One of**
-      - _string_
-      - _null_
-  - **`tmp_path`**: Path to directory to place temporary files.
+      - <a id="properties/general/properties/mgf_path/oneOf/0"></a>_string_
+      - <a id="properties/general/properties/mgf_path/oneOf/1"></a>_null_
+  - <a id="properties/general/properties/tmp_path"></a>**`tmp_path`**: Path to directory to place temporary files.
     - **One of**
-      - _string_
-      - _null_
-  - **`output_filename`**: Path and root name for output files.
+      - <a id="properties/general/properties/tmp_path/oneOf/0"></a>_string_
+      - <a id="properties/general/properties/tmp_path/oneOf/1"></a>_null_
+  - <a id="properties/general/properties/output_filename"></a>**`output_filename`**: Path and root name for output files.
     - **One of**
-      - _string_
-      - _null_
-  - **`log_level`** _(string)_: Logging level. Must be one of: `["debug", "info", "warning", "error", "critical"]`.
-  - **`const`** _(string)_: Const attribute. Must be: `"value"`.
-- **`ms2pip`** _(object)_: MS²PIP settings. Cannot contain additional properties.
-  - **`model`** _(string)_: MS²PIP model to use (see MS²PIP documentation). Default: `"HCD"`.
-  - **`frag_error`** _(number)_: MS2 error tolerance in Da. Minimum: `0`. Default: `0.02`.
-  - **`modifications`** _(array)_: Array of peptide mass modifications.
-    - **Items**: Refer to _[#/definitions/modifications](#definitions/modifications)_.
-- **`percolator`** _(object)_: Command line options directly passed to Percolator (see the Percolator wiki).
-- **`maxquant_to_rescore`** _(object)_: Settings specific to the MaxQuant pipeline. Cannot contain additional properties.
-  - **`mgf_dir`** _(string, required)_: Path to directory with MGF files.
-  - **`modification_mapping`** _(object, required)_: Mapping of MaxQuant modification labels to modifications names for MS²PIP. Default: `{}`.
-  - **`fixed_modifications`** _(object, required)_: Mapping of amino acids with fixed modifications to the modification name. Default: `{}`.
+      - <a id="properties/general/properties/output_filename/oneOf/0"></a>_string_
+      - <a id="properties/general/properties/output_filename/oneOf/1"></a>_null_
+  - <a id="properties/general/properties/log_level"></a>**`log_level`** _(string)_: Logging level. Must be one of: `["debug", "info", "warning", "error", "critical"]`.
+  - <a id="properties/general/properties/const"></a>**`const`** _(string)_: Const attribute. Must be: `"value"`.
+- <a id="properties/ms2pip"></a>**`ms2pip`** _(object)_: MS²PIP settings. Cannot contain additional properties.
+  - <a id="properties/ms2pip/properties/model"></a>**`model`** _(string)_: MS²PIP model to use (see MS²PIP documentation). Default: `"HCD"`.
+  - <a id="properties/ms2pip/properties/frag_error"></a>**`frag_error`** _(number)_: MS2 error tolerance in Da. Minimum: `0`. Default: `0.02`.
+  - <a id="properties/ms2pip/properties/modifications"></a>**`modifications`** _(array)_: Array of peptide mass modifications.
+    - <a id="properties/ms2pip/properties/modifications/items"></a>**Items**: Refer to _[#/definitions/modifications](#definitions/modifications)_.
+- <a id="properties/percolator"></a>**`percolator`** _(object)_: Command line options directly passed to Percolator (see the Percolator wiki).
+- <a id="properties/maxquant_to_rescore"></a>**`maxquant_to_rescore`** _(object)_: Settings specific to the MaxQuant pipeline. Cannot contain additional properties.
+  - <a id="properties/maxquant_to_rescore/properties/mgf_dir"></a>**`mgf_dir`** _(string, required)_: Path to directory with MGF files.
+  - <a id="properties/maxquant_to_rescore/properties/modification_mapping"></a>**`modification_mapping`** _(object, required)_: Mapping of MaxQuant modification labels to modifications names for MS²PIP. Default: `{}`.
+  - <a id="properties/maxquant_to_rescore/properties/fixed_modifications"></a>**`fixed_modifications`** _(object, required)_: Mapping of amino acids with fixed modifications to the modification name. Default: `{}`.
 
 ## Definitions
 
 - <a id="definitions/modifications"></a>**`modifications`** _(object)_: Peptide mass modifications, per amino acid. Cannot contain additional properties.
-  - **`name`** _(string, required)_: Unique name for modification.
-  - **`unimod_accession`** _(number, required)_: Unimod accession of modification. Must be an integer.
-  - **`mass_shift`** _(number, required)_: Mono-isotopic mass shift.
-  - **`amino_acid`**: Amino acid one-letter code, or null if amino acid-agnostic (e.g. N-term acetylation).
+  - <a id="definitions/modifications/properties/name"></a>**`name`** _(string, required)_: Unique name for modification.
+  - <a id="definitions/modifications/properties/unimod_accession"></a>**`unimod_accession`** _(number, required)_: Unimod accession of modification. Must be an integer.
+  - <a id="definitions/modifications/properties/mass_shift"></a>**`mass_shift`** _(number, required)_: Mono-isotopic mass shift.
+  - <a id="definitions/modifications/properties/amino_acid"></a>**`amino_acid`**: Amino acid one-letter code, or null if amino acid-agnostic (e.g. N-term acetylation).
     - **One of**
-      - _string_: Length must be equal to 1.
-      - _null_
-  - **`n_term`** _(boolean, required)_: Modification is N-terminal.
+      - <a id="definitions/modifications/properties/amino_acid/oneOf/0"></a>_string_: Length must be equal to 1.
+      - <a id="definitions/modifications/properties/amino_acid/oneOf/1"></a>_null_
+  - <a id="definitions/modifications/properties/n_term"></a>**`n_term`** _(boolean, required)_: Modification is N-terminal.

--- a/examples/vegetables.md
+++ b/examples/vegetables.md
@@ -4,20 +4,20 @@ _Vegetable preferences_
 
 ## Properties
 
-- **`fruits`** _(array)_
-  - **Items** _(string)_
-- **`vegetables`** _(array)_
-  - **Items**: Refer to _[#/definitions/veggie](#definitions/veggie)_.
+- <a id="properties/fruits"></a>**`fruits`** _(array)_
+  - <a id="properties/fruits/items"></a>**Items** _(string)_
+- <a id="properties/vegetables"></a>**`vegetables`** _(array)_
+  - <a id="properties/vegetables/items"></a>**Items**: Refer to _[#/definitions/veggie](#definitions/veggie)_.
 
 ## Definitions
 
 - <a id="definitions/veggie"></a>**`veggie`** _(object)_
-  - **`veggieName`** _(string, required)_: The name of the vegetable.
-  - **`veggieLike`** _(boolean, required)_: Do I like this vegetable?
-  - **`type_number`** _(array)_: The type and number of vegetable.
+  - <a id="definitions/veggie/properties/veggieName"></a>**`veggieName`** _(string, required)_: The name of the vegetable.
+  - <a id="definitions/veggie/properties/veggieLike"></a>**`veggieLike`** _(boolean, required)_: Do I like this vegetable?
+  - <a id="definitions/veggie/properties/type_number"></a>**`type_number`** _(array)_: The type and number of vegetable.
     - **Items**:
-      - _string_: The type of the vegetable.
-      - _number_: The number of vegetable.
+      - <a id="definitions/veggie/properties/type_number/items/0"></a>_string_: The type of the vegetable.
+      - <a id="definitions/veggie/properties/type_number/items/1"></a>_number_: The number of vegetable.
 
 ## Examples
 

--- a/tests/test_jsonschema2md.py
+++ b/tests/test_jsonschema2md.py
@@ -82,22 +82,37 @@ class TestDraft201909defs:
             "# JSON Schema\n\n",
             "*Food preferences*\n\n",
             "## Additional Properties\n\n",
-            "- **Additional Properties** *(object)*: Additional info about foods you may like.\n",
-            "  - **`^iLike(Meat|Drinks)$`** *(boolean)*: Do I like it?\n",
+            '- <a id="additionalProperties"></a>**Additional Properties** *(object)*: '
+            "Additional info about foods you may like.\n",
+            "  - <a "
+            'id="additionalProperties/patternProperties/%5EiLike%28Meat%7CDrinks%29%24"></a>**`^iLike(Meat|Drinks)$`** '
+            "*(boolean)*: Do I like it?\n",
             "## Unevaluated Properties\n\n",
-            "- **Unevaluated Properties** *(object)*: Anything else you want to add. Cannot contain additional properties.\n",
-            "  - **`^extraInfo[\\w]*$`** *(string)*: Anything else I might like to say.\n",
+            '- <a id="unevaluatedProperties"></a>**Unevaluated Properties** '
+            "*(object)*: Anything else you want to add. Cannot contain additional "
+            "properties.\n",
+            "  - <a "
+            'id="unevaluatedProperties/patternProperties/%5EextraInfo%5B%5Cw%5D%2A%24"></a>**`^extraInfo[\\w]*$`** '
+            "*(string)*: Anything else I might like to say.\n",
             "## Properties\n\n",
-            "- **`fruits`** *(array, required)*\n",
-            "  - **Items** *(string)*\n",
-            "- **`vegetables`** *(array)*: Items must be unique.\n",
-            "  - **Items**: Refer to *[#/$defs/veggie](#%24defs/veggie)*.\n",
-            '- **`taste`** *(string)*: How does it taste? Must match pattern: `^[a-z]*$` ([Test](https://regexr.com/?expression=%5E%5Ba-z%5D%2A%24)). Default: `"good"`.\n',
+            '- <a id="properties/fruits"></a>**`fruits`** *(array, required)*\n',
+            '  - <a id="properties/fruits/items"></a>**Items** *(string)*\n',
+            '- <a id="properties/vegetables"></a>**`vegetables`** *(array)*: Items must be unique.\n',
+            '  - <a id="properties/vegetables/items"></a>**Items**: Refer to '
+            "*[#/$defs/veggie](#%24defs/veggie)*.\n",
+            '- <a id="properties/taste"></a>**`taste`** *(string)*: How does it taste? '
+            "Must match pattern: `^[a-z]*$` "
+            "([Test](https://regexr.com/?expression=%5E%5Ba-z%5D%2A%24)). Default: "
+            '`"good"`.\n',
             "## Definitions\n\n",
             '- <a id="%24defs/veggie"></a>**`veggie`** *(object)*\n',
-            "  - **`veggieName`** *(string, required)*: The name of the vegetable. Length must be between 1 and 100 (inclusive).\n",
-            "  - **`veggieLike`** *(boolean, required, deprecated)*: Do I like this vegetable?\n",
-            "  - **`expiresAt`** *(string, format: date)*: When does the veggie expires.\n",
+            '  - <a id="%24defs/veggie/properties/veggieName"></a>**`veggieName`** '
+            "*(string, required)*: The name of the vegetable. Length must be between 1 "
+            "and 100 (inclusive).\n",
+            '  - <a id="%24defs/veggie/properties/veggieLike"></a>**`veggieLike`** '
+            "*(boolean, required, deprecated)*: Do I like this vegetable?\n",
+            '  - <a id="%24defs/veggie/properties/expiresAt"></a>**`expiresAt`** '
+            "*(string, format: date)*: When does the veggie expires.\n",
             "## Examples\n\n",
             "  ```json\n"
             "  {\n"
@@ -112,7 +127,8 @@ class TestDraft201909defs:
             "          }\n"
             "      ]\n"
             "  }\n"
-            "  ```\n\n",
+            "  ```\n"
+            "\n",
         ]
         assert expected_output == parser.parse_schema(self.test_schema)
 
@@ -308,8 +324,13 @@ class TestParser:
     def test_parse_object(self):
         """Test."""
         parser = jsonschema2md.Parser()
-        expected_output = ["- **`fruits`** *(array)*\n", "  - **Items** *(string)*\n"]
-        assert expected_output == parser._parse_object(self.test_schema["properties"]["fruits"], "fruits")
+        expected_output = [
+            '- <a id="properties/fruits"></a>**`fruits`** *(array)*\n',
+            '  - <a id="properties/fruits/items"></a>**Items** *(string)*\n',
+        ]
+        assert expected_output == parser._parse_object(
+            self.test_schema["properties"]["fruits"], "fruits", path=["properties", "fruits"]
+        )
 
     def test_parse_schema(self):
         """Test."""
@@ -318,20 +339,30 @@ class TestParser:
             "# JSON Schema\n\n",
             "*Food preferences*\n\n",
             "## Additional Properties\n\n",
-            "- **Additional Properties** *(object)*: Additional info about foods you may like.\n",
-            "  - **`^iLike(Meat|Drinks)$`** *(boolean)*: Do I like it?\n",
+            '- <a id="additionalProperties"></a>**Additional Properties** *(object)*: '
+            "Additional info about foods you may like.\n",
+            "  - <a "
+            'id="additionalProperties/patternProperties/%5EiLike%28Meat%7CDrinks%29%24"></a>**`^iLike(Meat|Drinks)$`** '
+            "*(boolean)*: Do I like it?\n",
             "## Properties\n\n",
-            "- **`fruits`** *(array)*\n",
-            "  - **Items** *(string)*\n",
-            "- **`vegetables`** *(array)*\n",
-            "  - **Items**: Refer to *[#/definitions/veggie](#definitions/veggie)*.\n",
-            "- **`cakes`** *(array)*: Contains schema must be matched at most 3 times.\n",
-            "  - **Contains**: Refer to *[#/definitions/cake](#definitions/cake)*.\n",
+            '- <a id="properties/fruits"></a>**`fruits`** *(array)*\n',
+            '  - <a id="properties/fruits/items"></a>**Items** *(string)*\n',
+            '- <a id="properties/vegetables"></a>**`vegetables`** *(array)*\n',
+            '  - <a id="properties/vegetables/items"></a>**Items**: Refer to '
+            "*[#/definitions/veggie](#definitions/veggie)*.\n",
+            '- <a id="properties/cakes"></a>**`cakes`** *(array)*: Contains schema '
+            "must be matched at most 3 times.\n",
+            '  - <a id="properties/cakes/contains"></a>**Contains**: Refer to '
+            "*[#/definitions/cake](#definitions/cake)*.\n",
             "## Definitions\n\n",
             '- <a id="definitions/veggie"></a>**`veggie`** *(object)*\n',
-            "  - **`veggieName`** *(string, required)*: The name of the vegetable.\n",
-            "  - **`veggieLike`** *(boolean, required)*: Do I like this vegetable?\n",
-            "  - **`expiresAt`** *(string, format: date, required <sub><sup>if `veggieLike` is set</sup></sub>)*: When does the veggie expires.\n",
+            '  - <a id="definitions/veggie/properties/veggieName"></a>**`veggieName`** '
+            "*(string, required)*: The name of the vegetable.\n",
+            '  - <a id="definitions/veggie/properties/veggieLike"></a>**`veggieLike`** '
+            "*(boolean, required)*: Do I like this vegetable?\n",
+            '  - <a id="definitions/veggie/properties/expiresAt"></a>**`expiresAt`** '
+            "*(string, format: date, required <sub><sup>if `veggieLike` is "
+            "set</sup></sub>)*: When does the veggie expires.\n",
             '- <a id="definitions/cake"></a>**`cake`** *(string)*: A cake.\n',
             "## Examples\n\n",
             "  ```json\n"
@@ -347,7 +378,8 @@ class TestParser:
             "          }\n"
             "      ]\n"
             "  }\n"
-            "  ```\n\n",
+            "  ```\n"
+            "\n",
         ]
         assert expected_output == parser.parse_schema(self.test_schema)
 
@@ -358,23 +390,41 @@ class TestParser:
             "# JSON Schema\n\n",
             "*Food preferences*\n\n",
             "## Additional Properties\n\n",
-            "- **Additional Properties** *(object)*: Additional info about foods you may like.\n",
-            "  - **`^iLike(Meat|Drinks)$`** *(boolean)*: Do I like it?\n",
+            '- <a id="additionalProperties"></a>**Additional Properties** *(object)*: '
+            "Additional info about foods you may like.\n",
+            "  - <a "
+            'id="additionalProperties/patternProperties/%5EiLike%28Meat%7CDrinks%29%24"></a>**`^iLike(Meat|Drinks)$`** '
+            "*(boolean)*: Do I like it?\n",
             "## Properties\n\n",
-            "- **`fruits`** *(array)*\n",
-            "  - **Items** *(string)*\n",
-            "- **`vegetables`** *(array)*\n",
-            "  - **Items**: Refer to *[#/definitions/veggie](#definitions/veggie)*.\n",
-            "- **`cakes`** *(array)*: Contains schema must be matched at most 3 times.\n",
-            "  - **Contains**: Refer to *[#/definitions/cake](#definitions/cake)*.\n",
+            '- <a id="properties/fruits"></a>**`fruits`** *(array)*\n',
+            '  - <a id="properties/fruits/items"></a>**Items** *(string)*\n',
+            '- <a id="properties/vegetables"></a>**`vegetables`** *(array)*\n',
+            '  - <a id="properties/vegetables/items"></a>**Items**: Refer to '
+            "*[#/definitions/veggie](#definitions/veggie)*.\n",
+            '- <a id="properties/cakes"></a>**`cakes`** *(array)*: Contains schema '
+            "must be matched at most 3 times.\n",
+            '  - <a id="properties/cakes/contains"></a>**Contains**: Refer to '
+            "*[#/definitions/cake](#definitions/cake)*.\n",
             "## Definitions\n\n",
             '- <a id="definitions/veggie"></a>**`veggie`** *(object)*\n',
-            "  - **`veggieName`** *(string, required)*: The name of the vegetable.\n",
-            "  - **`veggieLike`** *(boolean, required)*: Do I like this vegetable?\n",
-            "  - **`expiresAt`** *(string, format: date, required <sub><sup>if `veggieLike` is set</sup></sub>)*: When does the veggie expires.\n",
+            '  - <a id="definitions/veggie/properties/veggieName"></a>**`veggieName`** '
+            "*(string, required)*: The name of the vegetable.\n",
+            '  - <a id="definitions/veggie/properties/veggieLike"></a>**`veggieLike`** '
+            "*(boolean, required)*: Do I like this vegetable?\n",
+            '  - <a id="definitions/veggie/properties/expiresAt"></a>**`expiresAt`** '
+            "*(string, format: date, required <sub><sup>if `veggieLike` is "
+            "set</sup></sub>)*: When does the veggie expires.\n",
             '- <a id="definitions/cake"></a>**`cake`** *(string)*: A cake.\n',
             "## Examples\n\n",
-            "  ```yaml\n  fruits:\n  - apple\n  - orange\n  vegetables:\n  -   veggieName: cabbage\n      veggieLike: true\n  ```\n\n",
+            "  ```yaml\n"
+            "  fruits:\n"
+            "  - apple\n"
+            "  - orange\n"
+            "  vegetables:\n"
+            "  -   veggieName: cabbage\n"
+            "      veggieLike: true\n"
+            "  ```\n"
+            "\n",
         ]
         assert expected_output == parser.parse_schema(self.test_schema)
 
@@ -400,7 +450,7 @@ class TestParser:
             "# JSON Schema\n\n",
             "*Diet preferences*\n\n",
             "## Pattern Properties\n\n",
-            "- **`^iLike(Meat|Drinks)$`** *(boolean)*: Do I like it?\n",
+            '- <a id="patternProperties"></a>**`^iLike(Meat|Drinks)$`** *(boolean)*: Do I like it?\n',
         ]
 
         assert expected_output == parser.parse_schema(test_schema)
@@ -433,9 +483,10 @@ class TestParser:
             "# Fruits\n\n",
             "*Fruits I like*\n\n",
             "## Items\n\n",
-            "- **Items** *(object)*: A list of fruits. Number of properties must be at most 2.\n",
-            "  - **`name`** *(string)*: The name of the fruit.\n",
-            "  - **`sweet`** *(boolean)*: Whether it is sweet or not.\n",
+            '- <a id="items"></a>**Items** *(object)*: A list of fruits. Number of '
+            "properties must be at most 2.\n",
+            '  - <a id="items/properties/name"></a>**`name`** *(string)*: The name of the fruit.\n',
+            '  - <a id="items/properties/sweet"></a>**`sweet`** *(boolean)*: Whether it is sweet or not.\n',
         ]
 
         assert expected_output == parser.parse_schema(test_schema)
@@ -469,18 +520,63 @@ class TestParser:
             "# JSON Schema\n\n",
             "*Schema composition test case*\n\n",
             "## Properties\n\n",
-            "- **`all_of_example`**\n",
+            '- <a id="properties/all_of_example"></a>**`all_of_example`**\n',
             "  - **All of**\n",
-            "    - *number*\n",
-            "    - *integer*\n",
-            "- **`any_of_example`**\n",
+            '    - <a id="properties/all_of_example/allOf/0"></a>*number*\n',
+            '    - <a id="properties/all_of_example/allOf/1"></a>*integer*\n',
+            '- <a id="properties/any_of_example"></a>**`any_of_example`**\n',
             "  - **Any of**\n",
-            "    - *string*\n",
-            "    - *number*: Minimum: `0`.\n",
-            "- **`one_of_example`**: Default: `[1, 2, 3]`.\n",
+            '    - <a id="properties/any_of_example/anyOf/0"></a>*string*\n',
+            '    - <a id="properties/any_of_example/anyOf/1"></a>*number*: Minimum: `0`.\n',
+            '- <a id="properties/one_of_example"></a>**`one_of_example`**: Default: `[1, 2, 3]`.\n',
             "  - **One of**\n",
-            "    - *null*\n",
-            "    - *array*\n",
-            "      - **Items** *(number)*\n",
+            '    - <a id="properties/one_of_example/oneOf/0"></a>*null*\n',
+            '    - <a id="properties/one_of_example/oneOf/1"></a>*array*\n',
+            '      - <a id="properties/one_of_example/oneOf/1/items"></a>**Items** *(number)*\n',
+        ]
+        assert expected_output == parser.parse_schema(test_schema)
+
+    def test_pattern_ignore(self):
+        test_schema = {
+            "type": "object",
+            "properties": {
+                "general": {
+                    "description": "General settings.",
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "pipeline": {
+                            "description": "Pipeline to use, depending on input format",
+                            "type": "string",
+                            "enum": ["infer", "pin", "tandem", "maxquant", "msgfplus", "peptideshaker"],
+                            "default": "infer",
+                        },
+                    },
+                },
+                "ignoreme": {
+                    "description": "Ignored property",
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "thing": {
+                            "description": "the description",
+                            "type": "string",
+                            "enum": ["infer", "pin", "tandem", "maxquant", "msgfplus", "peptideshaker"],
+                            "default": "infer",
+                        },
+                    },
+                },
+            },
+        }
+        parser = jsonschema2md.Parser(ignore_patterns=[r".*ignoreme.*"])
+        expected_output = [
+            "# JSON Schema\n\n",
+            "## Properties\n\n",
+            '- <a id="properties/general"></a>**`general`** *(object)*: General '
+            "settings. Cannot contain additional properties.\n",
+            '  - <a id="properties/general/properties/pipeline"></a>**`pipeline`** '
+            "*(string)*: Pipeline to use, depending on input format. Must be one of: "
+            '`["infer", "pin", "tandem", "maxquant", "msgfplus", "peptideshaker"]`. '
+            'Default: `"infer"`.\n',
         ]
         assert expected_output == parser.parse_schema(test_schema)


### PR DESCRIPTION
- Adds the ability to ignore certain paths in the generated markdown
- For example, I have a `comment` field on my schemas I want to ignore.
- Not exposed to the CLI, just Python API.
- Test added